### PR TITLE
Set fixed size for product images in views and cards

### DIFF
--- a/component/shared/product/product-card.tsx
+++ b/component/shared/product/product-card.tsx
@@ -13,9 +13,9 @@ interface ProductCardProps {
 const ProductCard: FC<ProductCardProps> = ({ product }) => {
   return (
     <Card className="w-full max-w-sm sm:max-w-screen-sm shadow-none">
-      <CardHeader className="p-0 items-center">
+      <CardHeader className="p-0 items-center h-96 overflow-hidden">
         <Link href={PATH_DIR.PRODUCT_VIEW(product.slug)}>
-          <Image src={product.images[0]} alt={product.name} height={300} width={300} priority />
+          <Image src={product.images[0]} alt={product.name} height={300} width={300} className={'object-cover object-center h-96'} priority />
         </Link>
       </CardHeader>
       <CardContent className="p-4 grid gap-4">
@@ -24,7 +24,7 @@ const ProductCard: FC<ProductCardProps> = ({ product }) => {
           <h2 className="text-sm font-medium">{product.name}</h2>
         </Link>
         <div className="flex-between gap-4">
-          <ProductRating value={Number(product.rating)}/>
+          <ProductRating value={Number(product.rating)} />
           {product.stock > 0 ? <ProductPrice value={Number(product.price)} /> : <p className="text-destructive">{'Out of Stock'}</p>}
         </div>
       </CardContent>

--- a/component/shared/product/product-image.tsx
+++ b/component/shared/product/product-image.tsx
@@ -11,14 +11,21 @@ const ProductImage: FC<ProductImageProps> = ({ images }) => {
   const [current, setCurrent] = useState(0)
   return (
     <div className="space-y-4">
-      <Image src={images[current]} alt={'product-image'} width={1000} height={1000} className="min-h-[300px] object-cover object-center" priority />
+      <div className={'h-[480px] relative overflow-hidden'}>
+        <Image src={images[current]} alt={'product-image'} width={1000} height={1000} className="min-h-[300px] object-cover object-center" priority />
+      </div>
       <div className="flex">
         {images.map((image, index) => (
-          <div
-            key={index}
-            onClick={() => setCurrent(index)}
-            className={cn('border-b-4 mr-2 cursor-pointer hover:border-gray-700', current === index && 'border-gray-400')}>
-            <Image src={image} alt={'product-image'} width={80} height={80} className={cn(current !== index && 'scale-75')} />
+          <div key={index} onClick={() => setCurrent(index)} className={cn('w-[80px] h-[80px] overflow-hidden mr-2 cursor-pointer')}>
+            <Image
+              src={image}
+              alt={'product-image'}
+              width={80}
+              height={80}
+              className={cn(
+                current !== index ? 'border-t-4 hover:border-gray-700 scale-75 ease-in-out transition': 'border-gray-400 opacity-30'
+              )}
+            />
           </div>
         ))}
       </div>


### PR DESCRIPTION
Adjust product image sizes in both the product view and product card to ensure consistent display. This change addresses issue #21 by setting specific dimensions and overflow properties for better layout control.