### PR TITLE
Fix layout and responsiveness for product cards in Products and Home

### DIFF
--- a/app/(root)/search/page.tsx
+++ b/app/(root)/search/page.tsx
@@ -93,7 +93,7 @@ const SearchPage: FC<SearchPageProps> = async ({ searchParams }) => {
               ))}
             </div>
           </div>
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <div className="grid grid-cols-2 gap-4 md:grid-cols-3">
             {products.data.length <=0  && <NoResult data={products.data.length} />}
             {products.data.map((product, index) => (
                 <ProductCard key={index} product={product} />

--- a/component/shared/product/product-card.tsx
+++ b/component/shared/product/product-card.tsx
@@ -13,9 +13,9 @@ interface ProductCardProps {
 const ProductCard: FC<ProductCardProps> = ({ product }) => {
   return (
     <Card className="w-full max-w-sm sm:max-w-screen-sm shadow-none">
-      <CardHeader className="p-0 items-center h-96 overflow-hidden">
+      <CardHeader className="p-0 items-center h-60 md:h-96 overflow-hidden">
         <Link href={PATH_DIR.PRODUCT_VIEW(product.slug)}>
-          <Image src={product.images[0]} alt={product.name} height={300} width={300} className={'object-cover object-center h-96'} priority />
+          <Image src={product.images[0]} alt={product.name} height={300} width={300} className={'object-cover object-center h-60 md:h-96'} priority />
         </Link>
       </CardHeader>
       <CardContent className="p-4 grid gap-4">

--- a/component/shared/product/product-card.tsx
+++ b/component/shared/product/product-card.tsx
@@ -21,10 +21,10 @@ const ProductCard: FC<ProductCardProps> = ({ product }) => {
       <CardContent className="p-4 grid gap-4">
         <div className="text-xs">{product.brand}</div>
         <Link href={PATH_DIR.PRODUCT_VIEW(product.slug)}>
-          <h2 className="text-sm font-medium">{product.name}</h2>
+          <h2 className="text-xs font-medium">{product.name}</h2>
         </Link>
         <div className="flex-between gap-4">
-          <ProductRating value={Number(product.rating)} />
+          <ProductRating value={Number(product.rating)} className={'hidden md:block'} />
           {product.stock > 0 ? <ProductPrice value={Number(product.price)} /> : <p className="text-destructive">{'Out of Stock'}</p>}
         </div>
       </CardContent>

--- a/component/shared/product/product-list.tsx
+++ b/component/shared/product/product-list.tsx
@@ -15,7 +15,7 @@ const ProductList: FC<ProductListProps> = ({ data, title, limit }) => {
       <h2 className="h2-bold mb-4">{title}</h2>
       {data.length > 0 ? (
         <div className="flex justify-center">
-          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
             {limitedData.map((product: Product, index: number) => (
               <ProductCard key={index} product={product} />
             ))}

--- a/component/shared/product/product-rating.tsx
+++ b/component/shared/product/product-rating.tsx
@@ -1,6 +1,6 @@
 import { cn } from "lib"
 
-const ProductRating = ({ value, caption, className }: { value: number, className: string, caption?: string }) => {
+const ProductRating = ({ value, caption, className }: { value: number, className?: string, caption?: string }) => {
   const Full = () => (
     <svg xmlns="http://www.w3.org/2000/svg" className="text-black w-3 h-auto fill-current" viewBox="0 0 16 16">
       <path d="M3.612 15.443c-.386.198-.824-.149-.746-.592l.83-4.73L.173 6.765c-.329-.314-.158-.888.283-.95l4.898-.696L7.538.792c.197-.39.73-.39.927 0l2.184 4.327 4.898.696c.441.062.612.636.282.95l-3.522 3.356.83 4.73c.078.443-.36.79-.746.592L8 13.187l-4.389 2.256z" />

--- a/component/shared/product/product-rating.tsx
+++ b/component/shared/product/product-rating.tsx
@@ -1,5 +1,6 @@
+import { cn } from "lib"
 
-const ProductRating = ({ value, caption }: { value: number; caption?: string }) => {
+const ProductRating = ({ value, caption, className }: { value: number, className: string, caption?: string }) => {
   const Full = () => (
     <svg xmlns="http://www.w3.org/2000/svg" className="text-black w-3 h-auto fill-current" viewBox="0 0 16 16">
       <path d="M3.612 15.443c-.386.198-.824-.149-.746-.592l.83-4.73L.173 6.765c-.329-.314-.158-.888.283-.95l4.898-.696L7.538.792c.197-.39.73-.39.927 0l2.184 4.327 4.898.696c.441.062.612.636.282.95l-3.522 3.356.83 4.73c.078.443-.36.79-.746.592L8 13.187l-4.389 2.256z" />
@@ -17,7 +18,7 @@ const ProductRating = ({ value, caption }: { value: number; caption?: string }) 
   )
 
   return (
-    <div className="flex gap-2">
+    <div className={cn('flex gap-2', className)}>
       <div className="flex gap-1">
         {value >= 1 ? <Full /> : value >= 0.5 ? <Half /> : <Empty />}
         {value >= 2 ? <Full /> : value >= 1.5 ? <Half /> : <Empty />}

--- a/component/shared/promo/deal-countdown.tsx
+++ b/component/shared/promo/deal-countdown.tsx
@@ -72,12 +72,13 @@ const DealCountdown = () => {
           <h3 className={'text-3xl font-bold'}>{title}</h3>
           <p>{description}</p>
           {children}
+          <div className={cn('my-4 md:text-left text-center')}>
+            <LinkBtn variant={'secondary'} href={PATH_DIR.SEARCH}>
+              {en.view_product.view_products.label}
+            </LinkBtn>
+          </div>
         </div>
-        <div className={cn('my-4', hasEnded ? 'text-center' : 'text-center')}>
-          <LinkBtn variant={'secondary'} href={PATH_DIR.SEARCH}>
-            {en.view_product.view_products.label}
-          </LinkBtn>
-        </div>
+
         <div className={cn('flex justify-center sm:w-full', hasEnded && 'opacity-20')}>
           <Image src={ASSET_DIR.PROMO} alt={'promotion'} width={200} height={300} />
         </div>

--- a/component/shared/promo/deal-countdown.tsx
+++ b/component/shared/promo/deal-countdown.tsx
@@ -72,11 +72,13 @@ const DealCountdown = () => {
           <h3 className={'text-3xl font-bold'}>{title}</h3>
           <p>{description}</p>
           {children}
-          <div className={cn('mt-2', hasEnded ? 'text-left' : 'text-center')}>
-            <LinkBtn variant={'secondary'} href={PATH_DIR.SEARCH}>{en.view_product.view_products.label}</LinkBtn>
-          </div>
         </div>
-        <div className={'flex justify-center'}>
+        <div className={cn('my-4', hasEnded ? 'text-center' : 'text-center')}>
+          <LinkBtn variant={'secondary'} href={PATH_DIR.SEARCH}>
+            {en.view_product.view_products.label}
+          </LinkBtn>
+        </div>
+        <div className={cn('flex justify-center sm:w-full', hasEnded && 'opacity-20')}>
           <Image src={ASSET_DIR.PROMO} alt={'promotion'} width={200} height={300} />
         </div>
       </section>


### PR DESCRIPTION
Adjustments made to the grid layout to fit two product cards in a row, enhance responsiveness, and improve styling flexibility for components. This addresses layout issues identified in the project. Fixes #28