### PR TITLE
Adjust base path in next.config.js of vieux-carre-support

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -9,7 +9,9 @@ const nextConfig: NextConfig = {
         pathname: '/**'
       }
     ]
-  }
+  },
+  basePath   : '/support',
+  assetPrefix: '/support'
 }
 
 export default nextConfig


### PR DESCRIPTION
 Fix attemp by setting the basePath in the support app to serve all files (JS, CSS, etc.) under /support.