### PR TITLE
Development: Fixed Framer motion Image instance

### DIFF
--- a/component/shared/product/product-card.tsx
+++ b/component/shared/product/product-card.tsx
@@ -8,7 +8,7 @@ import { PATH_DIR } from 'config'
 import { transl } from 'lib'
 import ProductPrice from './product-price'
 
-const MotionImage = motion(Image)
+const MotionImage = motion.create(Image)
 
 interface ProductCardProps {
   product: Product

--- a/component/shared/product/product-carousel.tsx
+++ b/component/shared/product/product-carousel.tsx
@@ -8,7 +8,7 @@ import Autoplay from 'embla-carousel-autoplay'
 import { Carousel, CarouselContent, CarouselItem } from 'component/ui'
 import { PATH_DIR } from 'config'
 
-const MotionImage = motion(Image)
+const MotionImage = motion.create(Image)
 
 interface ProductCarouselProps {
     products: Product[]

--- a/component/shared/promo/promo-dotm-countdown.tsx
+++ b/component/shared/promo/promo-dotm-countdown.tsx
@@ -10,7 +10,7 @@ import { EllipsisLoader } from 'component/shared/loader'
 import { oneDay, oneHr, oneMin, oneSec, lastDayOfTheMonth } from 'config'
 import { cn, transl } from 'lib'
 
-const MotionImage = motion(Image)
+const MotionImage = motion.create(Image)
 
 const TARGET_DATE = lastDayOfTheMonth
 


### PR DESCRIPTION
Fixed error with framer motion deprecated motion()

```shell
motion() is deprecated. Use motion.create() instead.
```